### PR TITLE
Add graceful shutdown support for zero-downtime deployments

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,6 +127,13 @@ func (s *Server) Handler() http.Handler {
 	return handler
 }
 
+// Close gracefully shuts down the server's background resources.
+// This should be called during application shutdown to stop background goroutines.
+func (s *Server) Close() error {
+	s.sessions.Close()
+	return nil
+}
+
 // PageData holds common data for page rendering
 type PageData struct {
 	Title             string


### PR DESCRIPTION
## Summary

- Server now handles SIGTERM/SIGINT signals for graceful shutdown
- Waits for in-flight requests to complete before exiting (30s timeout)
- Properly closes session cleanup background goroutine via `Server.Close()`
- Enables zero-downtime deployments in Kubernetes and similar environments

## Changes

| File | Description |
|------|-------------|
| `cmd/coinops/serve.go` | Rewritten with `http.Server` struct, signal handling, shutdown orchestration |
| `internal/server/server.go` | Added `Close()` method to stop background goroutines |
| Various | go fmt formatting fixes |

## Shutdown Flow

```
Signal received (SIGTERM/SIGINT) →
Stop accepting new connections →
Wait for in-flight requests (up to 30s) →
Close server resources (session cleanup) →
Exit cleanly
```

## Test plan

- [x] All 91 tests pass
- [x] Build succeeds
- [ ] Manual verification:
  1. Start server: `make run`
  2. Send a slow request (e.g., `/generate-report` takes 3s)
  3. During request, send SIGTERM: `kill -TERM <pid>`
  4. Verify request completes before server exits
  5. Verify "graceful_shutdown_complete" in logs

Closes #17